### PR TITLE
Add option to turn off aligning key values

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options are :
  * {number} [maxDepth]           : maximum sublevel of nested objects/arrays to output. Default: 3
  * {boolean} [noColor]           : disable colors. Default: false
  * {colors} [colors]             : Output colors. See below
+ * {boolean} [alignKeyValues]    : Align key values. Default: true
 
 Colors are :
  * {string} [keys]     : Objects keys color. Default: green

--- a/lib/prettyoutput.js
+++ b/lib/prettyoutput.js
@@ -55,7 +55,7 @@ internals.parseOptions = (opts) => {
         indentation: indentation,
         maxDepth: opts.maxDepth || 3,
         colors: (!opts.noColor) ? colors : null,
-        alignKeyValues: _.has(opts, 'alignKeyValues') ? opts.alignKeyValues : true
+        alignKeyValues: _.isBoolean(opts.alignKeyValues) ? opts.alignKeyValues : true
     }
 }
 

--- a/lib/prettyoutput.js
+++ b/lib/prettyoutput.js
@@ -15,6 +15,7 @@ exports.internals = internals
  * @property {number} [maxDepth] - maximum sublevel of nested objects/arrays to go to. Default: 5
  * @property {boolean} [noColor] - Disable coloring. Default: false
  * @property {colors} [colors] - input colors
+ * @property {boolean} [alignKeyValues] - Align key values. Default: true
  */
 
 /**
@@ -53,7 +54,8 @@ internals.parseOptions = (opts) => {
     return {
         indentation: indentation,
         maxDepth: opts.maxDepth || 3,
-        colors: (!opts.noColor) ? colors : null
+        colors: (!opts.noColor) ? colors : null,
+        alignKeyValues: _.has(opts, 'alignKeyValues') ? opts.alignKeyValues : true
     }
 }
 
@@ -116,7 +118,7 @@ module.exports = function (input, opts, indent) {
             // Else render an object
             const isError = input instanceof Error
             const keys = Object.getOwnPropertyNames(input)
-            const valueColumn = utils.maxLength(keys)
+            const valueColumn = options.alignKeyValues ? utils.maxLength(keys) : 0
             _.forEachRight(keys, (key) => {
                 const value = input[key]
 

--- a/test/prettyoutput.js
+++ b/test/prettyoutput.js
@@ -224,6 +224,17 @@ describe('prettyoutput general tests', () => {
             ''
         ].join('\n'))
     })
+
+    it('should allow turning off aligning hash key values', () => {
+        const input = { veryLargeParam: 'first string', param: 'second string' }
+        const output = prettyoutput(input, { alignKeyValues: false })
+
+        output.should.equal([
+            `${colors.green('veryLargeParam: ')}first string`,
+            `${colors.green('param: ')}second string`,
+            ''
+        ].join('\n'))
+    })
 })
 
 describe('Printing numbers, booleans and other objects', () => {


### PR DESCRIPTION
Allows a user to turn off object-key alignment padding:

Before:

```js
const data = { someKey: 'a value', someMuchLongerKey: 'another value' }

prettyoutput(data)
```

```yaml
someKey:              a value
someMuchLongerKey:    another value
```

After:

```js
const data = { someKey: 'a value', someMuchLongerKey: 'another value' }

prettyoutput(data, { alignKeyValues: false })
```

```yaml
someKey: a value
someMuchLongerKey: another value
```

The code here takes advantage of the fact that [`_.repeat`](https://lodash.com/docs/4.17.4#repeat) called with a negative number just returns an empty string.

Closes https://github.com/keepitcool/prettyoutput/issues/1