### PR TITLE
Handle undefined values

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,14 @@ Options are :
  * {colors} [colors]             : Output colors. See below
 
 Colors are :
- * {string} [keys]     : Objects keys color. Default: green
- * {string} [dash]     : Array prefixing dash ("- "). Default: green
- * {string} [number]   : Numbers color. Default: blue
- * {string} [string]   : Strings color. Default: no color
- * {string} [true]     : Boolean value 'true' color. Default: green
- * {string} [false]    : Boolean value 'false' color. Default: red
- * {string} [null]     : 'Null' color. Default: grey
+ * {string} [keys]       : Objects keys color. Default: green
+ * {string} [dash]       : Array prefixing dash ("- "). Default: green
+ * {string} [number]     : Numbers color. Default: blue
+ * {string} [string]     : Strings color. Default: no color
+ * {string} [true]       : Boolean value 'true' color. Default: green
+ * {string} [false]      : Boolean value 'false' color. Default: red
+ * {string} [null]       : 'Null' color. Default: grey
+ * {string} [undefined]  : 'Undefined' color. Default: grey
 
 Example using options :
 ```javascript

--- a/lib/prettyoutput.js
+++ b/lib/prettyoutput.js
@@ -45,7 +45,8 @@ internals.parseOptions = (opts) => {
         string: optsColors.string || null,
         true: optsColors.true || 'green',
         false: optsColors.false || 'red',
-        null: optsColors.null || 'grey'
+        null: optsColors.null || 'grey',
+        undefined: optsColors.undefined || 'grey'
     }
 
     const indentation = (opts.indentationLength) ? utils.indent(opts.indentationLength) : utils.indent(2)

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -23,6 +23,8 @@ exports.inputColor = function (input, colors) {
 
     if (input === null) return colors.null
 
+    if (input === undefined) return colors.undefined
+
     if (type === 'number') return colors.number
 
     return null

--- a/lib/typeInspect.js
+++ b/lib/typeInspect.js
@@ -8,7 +8,7 @@
 exports.isSerializable = function (input) {
     const type = typeof input
     return (type === 'boolean' || type === 'number' ||
-            input === null || input instanceof Date ||
+            input === null || input instanceof Date || input === undefined ||
             exports.isSingleLineString(input) || exports.isEmptyArray(input))
 }
 

--- a/test/prettyoutput.js
+++ b/test/prettyoutput.js
@@ -253,6 +253,13 @@ describe('Printing numbers, booleans and other objects', () => {
         output.should.equal(`    ${colors.grey('null')}\n`)
     })
 
+    it('should print undefined correctly ', () => {
+        const input = undefined
+        const output = prettyoutput(input, {}, 4)
+
+        output.should.equal(`    ${colors.grey('undefined')}\n`)
+    })
+
     it('should print an Error correctly ', () => {
         Error.stackTraceLimit = 1
         const input = new Error('foo')


### PR DESCRIPTION
If you try to serialize an object like

```js
{
  config: {
    key1: 'key1',
    key2: 'key2',
    key3: undefined
  }
}
```

You'll be greeted with the following error:

> /.../node_modules/prettyoutput/lib/prettyoutput.js:120
>             const keys = Object.getOwnPropertyNames(input)
>                                 ^
> 
> TypeError: Cannot convert undefined or null to object

This PR makes `undefined` values serializable, so the above would result in:

```yml
config:
  key1: key1
  key2: key2
  key3: undefined
```