### PR TITLE
Fix: upgrade lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "colors": "1.1.2",
     "commander": "2.9.0",
-    "lodash": "4.16.6"
+    "lodash": "4.17.10"
   },
   "devDependencies": {
     "columnify": "1.5.4",


### PR DESCRIPTION
## Description

### Improvements

- Bump `lodash` version to 4.17.10 to resolve a vulnerability (see https://nodesecurity.io/advisories/577) detected using `npm audit`

- Resolve #4 