### PR TITLE
Add option to disable key separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Options are :
  * {colors} [colors]             : Output colors. See below
  * {boolean} [alignKeyValues]    : Align key values. Default: true
  * {boolean} [hideUndefined]     : Do not display undefined values. Default: false
+ * {boolean} [noSeparator]       : Do not display key separator Default: false
 
 Colors are :
  * {string} [keys]       : Objects keys color. Default: green

--- a/lib/prettyoutput.js
+++ b/lib/prettyoutput.js
@@ -17,6 +17,7 @@ exports.internals = internals
  * @property {colors} [colors] - input colors
  * @property {boolean} [alignKeyValues] - Align key values. Default: true
  * @property {boolean} [hideUndefined] - Show undefined values. Default: false
+ * @property {boolean} [noSeparator] - Do not display key separator. Default: false
  */
 
 /**
@@ -57,7 +58,8 @@ internals.parseOptions = opts => {
         maxDepth: opts.maxDepth || 3,
         colors: !opts.noColor ? colors : null,
         alignKeyValues: _.isBoolean(opts.alignKeyValues) ? opts.alignKeyValues : true,
-        hideUndefined: _.isBoolean(opts.hideUndefined) ? opts.hideUndefined : false
+        hideUndefined: _.isBoolean(opts.hideUndefined) ? opts.hideUndefined : false,
+        noSeparator: _.isBoolean(opts.noSeparator) ? opts.noSeparator : false
     }
 }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -57,7 +57,7 @@ exports.renderEmptyArray = function(options, indentation) {
 
 exports.renderObjectKey = function(key, options, indentation) {
     const colors = options.colors || {}
-    const output = `${indentation}${key}: `
+    const output = `${indentation}${key}${options.noSeparator ? '' : ':'} `
 
     return utils.colorString(output, colors.keys)
 }


### PR DESCRIPTION
I've added an option in my fork to not have the ':' separator. Here is a pull request if you are interested in adding.
<img width="211" alt="Screen Shot 2019-11-05 at 11 26 43 AM" src="https://user-images.githubusercontent.com/777498/68234777-397f6f00-ffbf-11e9-87e0-f7215e21a758.png">
